### PR TITLE
use bindings to search for addons

### DIFF
--- a/lib/sys.js
+++ b/lib/sys.js
@@ -7,7 +7,7 @@ var util = require('util');
 
 var assert = require('assert-plus');
 
-var binding = require('../build/Release/syslog');
+var binding = require('bindings')('syslog');
 
 
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
         "url": "git://github.com/mcavage/node-bunyan-syslog.git"
     },
     "dependencies": {
-        "assert-plus": "0.1.4"
+        "assert-plus": "0.1.4",
+        "bindings": "^1.2.1"
     },
     "devDependencies": {
         "bunyan": "0.21.4",


### PR DESCRIPTION
For local development I'm using a debug build of node, which results in the following when trying to use this library.

```
npm test

> bunyan-syslog@0.2.2 test /Users/tmpvar/work/js/node-bunyan-syslog
> tap test


module.js:340
    throw err;
          ^
Error: Cannot find module '../build/Release/syslog'
...
```

and so on. This patch fixes the immediate issue of not being able to find the binding, the other test failures will be added in a separate issue.
