### PR TITLE
Update dependencies. nan@1.8.4 allows build on io.js 2.3.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
   },
   "dependencies": {
     "assert-plus": "0.1.5",
-    "nan": "1.6.2"
+    "nan": "1.8.4"
   },
   "devDependencies": {
-    "bunyan": "1.3.4",
-    "tap": "0.6.0"
+    "bunyan": "1.4.0",
+    "tap": "1.2.1"
   },
   "scripts": {
     "test": "tap test"


### PR DESCRIPTION
Won't build on io.js 2.3.0 without a nan update.
