### PR TITLE
Update nan for io.js 2.x.x compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
     "url": "git://github.com/mcavage/node-bunyan-syslog.git"
   },
   "dependencies": {
-    "assert-plus": "0.1.5",
-    "nan": "1.6.2"
+    "assert-plus": "^0.1.5",
+    "nan": "^1.8.4"
   },
   "devDependencies": {
-    "bunyan": "1.3.4",
-    "tap": "0.6.0"
+    "bunyan": "^1.4.0",
+    "tap": "^1.2.1"
   },
   "scripts": {
     "test": "tap test"


### PR DESCRIPTION
Won't build on io.js 2.3.0 without a nan update.

Preferred alternative to https://github.com/mcavage/node-bunyan-syslog/pull/21

If bunyan-syslog was already using semver version ranges this PR wouldn't be necessary as nan would have automatically updated to latest.
