### PR TITLE
Upgrade nan so it supports latest node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "assert-plus": "0.1.5",
-    "nan": "2.4.x"
+    "nan": "2.7.0"
   },
   "devDependencies": {
     "bunyan": "1.5.x",


### PR DESCRIPTION
The latest versions of node are not currently supported. Updating nan to provide more up to date support for node.